### PR TITLE
fixed xt_deleteModel.

### DIFF
--- a/demo_XTFMDB/XTFMDB/NSObject+XTFMDB.m
+++ b/demo_XTFMDB/XTFMDB/NSObject+XTFMDB.m
@@ -238,7 +238,7 @@ static void *key_pkid = &key_pkid;
 #pragma mark - delete
 - (BOOL)xt_deleteModel
 {
-    return [[self class] deleteModelWhere:[NSString stringWithFormat:@"pkid = '%d'",self.pkid]] ;
+    return [[self class] xt_deleteModelWhere:[NSString stringWithFormat:@"pkid = '%d'",self.pkid]] ;
 }
 
 + (BOOL)xt_deleteModelWhere:(NSString *)strWhere


### PR DESCRIPTION
xt_deleteModel 调用类方法删除的时候，漏了xt_前缀，应该是typo。
NSObject的类删除方法是`+ (BOOL)xt_deleteModelWhere:(NSString *)strWhere`，
`+ (BOOL)deleteModelWhere:(NSString *)strWhere`是XTDBModel的删除方法。